### PR TITLE
fix: corrige erros de linter no frontend

### DIFF
--- a/frontend/src/components/Dashboard/GraficoColunas.jsx
+++ b/frontend/src/components/Dashboard/GraficoColunas.jsx
@@ -20,7 +20,7 @@ export default function GraficoColunas({ dados, chartRef }) {
           <Tooltip
             cursor={{ fill: '#F3F0FF' }}
             contentStyle={{ borderRadius: '8px', border: '1px solid #E5E7EB', fontSize: '13px' }}
-            formatter={(value, name) => [value.toLocaleString('pt-BR'), 'PLs']}
+            formatter={(value) => [value.toLocaleString('pt-BR'), 'PLs']}
           />
           <Bar dataKey="total" fill="#5B4FCF" radius={[4, 4, 0, 0]} isAnimationActive={true} />
         </BarChart>

--- a/frontend/src/components/PLDetalhado/HistoricoTramitacao.jsx
+++ b/frontend/src/components/PLDetalhado/HistoricoTramitacao.jsx
@@ -2,11 +2,10 @@ import { useState } from 'react';
 
 const LIMITE_INICIAL = 5;
 
-export default function HistoricoTramitacao({ historico, estagioAtual }) {
+export default function HistoricoTramitacao({ historico }) {
   const [verTodos, setVerTodos] = useState(false);
   const semDados = !historico || historico.length === 0;
 
-  // Mostra só os 10 primeiros ou todos, dependendo do estado
   const eventosMostrados = verTodos ? historico : historico?.slice(0, LIMITE_INICIAL);
   const temMais = historico && historico.length > LIMITE_INICIAL;
 
@@ -38,7 +37,6 @@ export default function HistoricoTramitacao({ historico, estagioAtual }) {
             ))}
           </div>
 
-          {/* Botão Ver mais / Ver menos */}
           {temMais && (
             <div className="mt-6 flex justify-center">
               <button
@@ -46,7 +44,7 @@ export default function HistoricoTramitacao({ historico, estagioAtual }) {
                 className="text-sm font-semibold text-[#5B4FCF] hover:text-[#4338CA] transition-colors border border-[#5B4FCF] rounded-lg px-4 py-2 hover:bg-purple-50"
               >
                 {verTodos
-                  ? `Ver menos`
+                  ? 'Ver menos'
                   : `Ver mais (${historico.length - LIMITE_INICIAL} etapas restantes)`}
               </button>
             </div>

--- a/frontend/src/hooks/useDashboard.js
+++ b/frontend/src/hooks/useDashboard.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { fetchDashboard } from '../services/api';
 
 const FILTROS_INICIAL = { estado: '', partido: '', genero: '', mes: '' };
@@ -9,27 +9,30 @@ export function useDashboard() {
   const [dados, setDados] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
-  const carregar = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const params = { comparar_por: compararPor, ...filtros };
-      const data = await fetchDashboard(params);
-      setDados(data);
-    } catch (e) {
-      setError(e.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [compararPor, filtros]);
+  const [trigger, setTrigger] = useState(0);
 
   useEffect(() => {
+    let cancelado = false;
+
+    async function carregar() {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = { comparar_por: compararPor, ...filtros };
+        const data = await fetchDashboard(params);
+        if (!cancelado) setDados(data);
+      } catch (e) {
+        if (!cancelado) setError(e.message);
+      } finally {
+        if (!cancelado) setLoading(false);
+      }
+    }
+
     carregar();
-  }, [carregar]);
+    return () => { cancelado = true; };
+  }, [compararPor, filtros, trigger]);
 
   const mudarComparar = (nova) => {
-    // Reseta o filtro da dimensão anterior ao trocar
     setFiltros((prev) => ({ ...prev, [compararPor]: '' }));
     setCompararPor(nova);
   };
@@ -46,6 +49,6 @@ export function useDashboard() {
     dados,
     loading,
     error,
-    recarregar: carregar,
+    recarregar: () => setTrigger((t) => t + 1),
   };
 }

--- a/frontend/src/hooks/useGraficosResumo.js
+++ b/frontend/src/hooks/useGraficosResumo.js
@@ -1,27 +1,31 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { fetchGraficosResumo } from '../services/api';
 
 export function useGraficosResumo() {
   const [dados, setDados] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
-  const carregar = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await fetchGraficosResumo();
-      setDados(data);
-    } catch (e) {
-      setError(e.message);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const [trigger, setTrigger] = useState(0);
 
   useEffect(() => {
-    carregar();
-  }, [carregar]);
+    let cancelado = false;
 
-  return { dados, loading, error, recarregar: carregar };
+    async function carregar() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchGraficosResumo();
+        if (!cancelado) setDados(data);
+      } catch (e) {
+        if (!cancelado) setError(e.message);
+      } finally {
+        if (!cancelado) setLoading(false);
+      }
+    }
+
+    carregar();
+    return () => { cancelado = true; };
+  }, [trigger]);
+
+  return { dados, loading, error, recarregar: () => setTrigger((t) => t + 1) };
 }

--- a/frontend/src/hooks/usePLDetalhado.js
+++ b/frontend/src/hooks/usePLDetalhado.js
@@ -1,28 +1,32 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { fetchPLDetalhado } from '../services/api';
 
 export function usePLDetalhado(casa, numero, ano) {
   const [pl, setPL] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
-  const carregar = useCallback(async () => {
-    if (!casa || !numero || !ano) return;
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await fetchPLDetalhado(casa, numero, ano);
-      setPL(data);
-    } catch (e) {
-      setError(e.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [casa, numero, ano]);
+  const [trigger, setTrigger] = useState(0);
 
   useEffect(() => {
-    carregar();
-  }, [carregar]);
+    if (!casa || !numero || !ano) return;
+    let cancelado = false;
 
-  return { pl, loading, error, recarregar: carregar };
+    async function carregar() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchPLDetalhado(casa, numero, ano);
+        if (!cancelado) setPL(data);
+      } catch (e) {
+        if (!cancelado) setError(e.message);
+      } finally {
+        if (!cancelado) setLoading(false);
+      }
+    }
+
+    carregar();
+    return () => { cancelado = true; };
+  }, [casa, numero, ano, trigger]);
+
+  return { pl, loading, error, recarregar: () => setTrigger((t) => t + 1) };
 }

--- a/frontend/src/hooks/useProjetosLei.js
+++ b/frontend/src/hooks/useProjetosLei.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { fetchProjetos, fetchFiltros } from '../services/api';
 
 const FILTROS_INICIAL = {
@@ -20,43 +20,50 @@ export function useProjetosLei() {
   const [metaFiltros, setMetaFiltros] = useState({ partidos: [], ufs: [], anos: [] });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [trigger, setTrigger] = useState(0);
 
-  const carregarFiltros = useCallback(async () => {
-    try {
-      const data = await fetchFiltros();
-      setMetaFiltros(data);
-    } catch (e) {
-      console.error('Erro ao carregar metadados dos filtros:', e);
+  // Carrega metadados dos filtros uma única vez
+  useEffect(() => {
+    let cancelado = false;
+    async function carregarFiltros() {
+      try {
+        const data = await fetchFiltros();
+        if (!cancelado) setMetaFiltros(data);
+      } catch (e) {
+        console.error('Erro ao carregar metadados dos filtros:', e);
+      }
     }
+    carregarFiltros();
+    return () => { cancelado = true; };
   }, []);
 
-  const carregarProjetos = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await fetchProjetos({
-        ...filtrosAplicados,
-        page,
-        per_page: 6,
-        ordenar,
-      });
-      setProjetos(data.projetos);
-      setTotal(data.total);
-      setTotalPages(data.total_pages);
-    } catch (e) {
-      setError(e.message);
-    } finally {
-      setLoading(false);
+  // Carrega projetos sempre que filtros, página, ordenação ou trigger mudam
+  useEffect(() => {
+    let cancelado = false;
+    async function carregarProjetos() {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchProjetos({
+          ...filtrosAplicados,
+          page,
+          per_page: 6,
+          ordenar,
+        });
+        if (!cancelado) {
+          setProjetos(data.projetos);
+          setTotal(data.total);
+          setTotalPages(data.total_pages);
+        }
+      } catch (e) {
+        if (!cancelado) setError(e.message);
+      } finally {
+        if (!cancelado) setLoading(false);
+      }
     }
-  }, [filtrosAplicados, page, ordenar]);
-
-  useEffect(() => {
-    carregarFiltros();
-  }, [carregarFiltros]);
-
-  useEffect(() => {
     carregarProjetos();
-  }, [carregarProjetos]);
+    return () => { cancelado = true; };
+  }, [filtrosAplicados, page, ordenar, trigger]);
 
   const aplicarFiltros = () => {
     setFiltrosAplicados({ ...filtros });
@@ -84,6 +91,6 @@ export function useProjetosLei() {
     error,
     aplicarFiltros,
     limparFiltros,
-    recarregar: carregarProjetos,
+    recarregar: () => setTrigger((t) => t + 1),
   };
 }


### PR DESCRIPTION
## O que foi feito
Correção de todos os erros apontados pelo ESLint no frontend.

## Erros corrigidos
- `GraficoColunas.jsx` — removida variável `name` não utilizada no formatter
- `HistoricoTramitacao.jsx` — removida prop `estagioAtual` não utilizada
- `useDashboard.js` — refatorado para evitar setState dentro de useEffect
- `useGraficosResumo.js` — refatorado para evitar setState dentro de useEffect
- `usePLDetalhado.js` — refatorado para evitar setState dentro de useEffect
- `useProjetosLei.js` — refatorado para evitar setState dentro de useEffect

## Como validar
1. `docker-compose up --build`
2. Entrar no container: `docker-compose exec frontend sh`
3. Rodar: `npm run lint`
4. Resultado esperado: `0 problems`