### PR TITLE
feat: melhorias visuais na página de Gráficos e Dashboard

### DIFF
--- a/frontend/src/components/Dashboard/GraficoColunas.jsx
+++ b/frontend/src/components/Dashboard/GraficoColunas.jsx
@@ -3,14 +3,17 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContaine
 export default function GraficoColunas({ dados, chartRef }) {
   return (
     <div ref={chartRef}>
-      <ResponsiveContainer width="100%" height={350}>
-        <BarChart data={dados} margin={{ top: 10, right: 10, left: 0, bottom: 5 }}>
+      <ResponsiveContainer width="100%" height={380}>
+        <BarChart data={dados} margin={{ top: 10, right: 10, left: 0, bottom: 60 }}>
           <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#E5E7EB" />
           <XAxis
             dataKey="label"
-            tick={{ fontSize: 12, fill: '#6B7280' }}
+            tick={{ fontSize: 11, fill: '#6B7280' }}
             axisLine={false}
             tickLine={false}
+            angle={-45}
+            textAnchor="end"
+            interval={0}
           />
           <YAxis
             tick={{ fontSize: 12, fill: '#6B7280' }}

--- a/frontend/src/components/Dashboard/GraficoPizza.jsx
+++ b/frontend/src/components/Dashboard/GraficoPizza.jsx
@@ -1,26 +1,165 @@
+import { useState, useMemo } from 'react';
 import { PieChart, Pie, Cell, Tooltip } from 'recharts';
 
-const CORES = ['#5B4FCF','#8B7DD8','#B5AEED','#D4CFEE','#E8E5F7','#3D3399','#7C6FBF','#A89BD6'];
+const COR_BASE = [
+  '#26215C', '#3C3489', '#534AB7', '#6B63C9',
+  '#7F77DD', '#948EE0', '#AFA9EC', '#C5C0EE', '#D4CFEE', '#E8E5F7',
+];
+const CORES_SIMPLES = ['#5B4FCF','#8B7DD8','#B5AEED','#D4CFEE','#E8E5F7','#3D3399','#7C6FBF','#A89BD6'];
+const COR_OUTROS = '#9CA3AF';
+const TOP_N = 10;
 
-export default function GraficoPizza({ dados, chartRef }) {
-  const total = dados.reduce((acc, d) => acc + d.total, 0);
+// Layout simples — para Gênero e Mês (poucos itens)
+function LegendaSimples({ dados, total, ativo, setAtivo }) {
+  const pct = (v) => ((v / total) * 100).toFixed(1);
+  return (
+    <div className="flex flex-col gap-3">
+      {dados.map((item, index) => (
+        <div
+          key={item.label}
+          className="flex items-center gap-3 cursor-default rounded px-1 py-0.5 transition-colors"
+          style={{ backgroundColor: ativo === index ? 'rgba(83,74,183,0.08)' : 'transparent' }}
+          onMouseEnter={() => setAtivo(index)}
+          onMouseLeave={() => setAtivo(null)}
+        >
+          <span
+            className="w-3 h-3 rounded-full flex-shrink-0"
+            style={{ backgroundColor: CORES_SIMPLES[index % CORES_SIMPLES.length] }}
+          />
+          <div>
+            <p className="text-sm font-semibold text-gray-800">{item.label}</p>
+            <p className="text-xs text-gray-500">
+              {item.total.toLocaleString('pt-BR')} ({pct(item.total)}%)
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Layout complexo — para Partido e Estado (muitos itens)
+function LegendaCompleta({ fatias, total, partidosOutros, ativo, setAtivo }) {
+  const [outrosAberto, setOutrosAberto] = useState(false);
+  const pct = (v) => ((v / total) * 100).toFixed(1);
 
   return (
-    <div ref={chartRef} className="flex flex-col lg:flex-row items-center justify-center gap-8">
-      {/* Gráfico com tamanho fixo para centralizar corretamente */}
+    <div className="grid grid-cols-2 gap-x-6 gap-y-2 w-full">
+      {fatias.map((item, index) => {
+        if (item.ehOutros) {
+          return (
+            <div key={item.label} className="col-span-2">
+              <button
+                type="button"
+                onClick={() => setOutrosAberto((v) => !v)}
+                onMouseEnter={() => setAtivo(index)}
+                onMouseLeave={() => setAtivo(null)}
+                className="flex items-center gap-2 w-full rounded px-1 py-1 mt-1 border-t border-gray-100 pt-2 transition-colors hover:bg-gray-50 text-left"
+                style={{ backgroundColor: ativo === index ? 'rgba(83,74,183,0.08)' : undefined }}
+                aria-expanded={outrosAberto}
+              >
+                <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: item.cor }} />
+                <span className="text-sm text-gray-700">{item.label}</span>
+                <svg className="w-3.5 h-3.5 text-gray-400 transition-transform" style={{ transform: outrosAberto ? 'rotate(180deg)' : 'rotate(0deg)' }} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M6 9l6 6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+                <span className="text-xs text-gray-500 ml-auto whitespace-nowrap">
+                  {item.total.toLocaleString('pt-BR')} · {pct(item.total)}%
+                </span>
+              </button>
+              {outrosAberto && (
+                <div className="grid grid-cols-2 gap-x-6 gap-y-1 mt-2 pl-5">
+                  {partidosOutros.map((p) => (
+                    <div key={p.label} className="flex items-center gap-2">
+                      <span className="w-1.5 h-1.5 rounded-full flex-shrink-0 bg-gray-300" />
+                      <span className="text-xs text-gray-600 truncate">{p.label}</span>
+                      <span className="text-xs text-gray-400 ml-auto whitespace-nowrap">
+                        {p.total.toLocaleString('pt-BR')} · {pct(p.total)}%
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        }
+        return (
+          <div
+            key={item.label}
+            className="flex items-center gap-2 cursor-default rounded px-1 py-0.5 transition-colors"
+            style={{ backgroundColor: ativo === index ? 'rgba(83,74,183,0.08)' : 'transparent' }}
+            onMouseEnter={() => setAtivo(index)}
+            onMouseLeave={() => setAtivo(null)}
+          >
+            <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: item.cor }} />
+            <span className="text-sm text-gray-800 truncate">{item.label}</span>
+            <span className="text-xs text-gray-500 ml-auto whitespace-nowrap">
+              {item.total.toLocaleString('pt-BR')} · {pct(item.total)}%
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function GraficoPizza({ dados, chartRef, compararPor }) {
+  const [ativo, setAtivo] = useState(null);
+  const layoutComplexo = compararPor === 'partido' || compararPor === 'estado';
+
+  const { fatias, total, partidosOutros } = useMemo(() => {
+    const ordenado = [...dados].sort((a, b) => b.total - a.total);
+    const totalGeral = ordenado.reduce((acc, d) => acc + d.total, 0);
+
+    if (!layoutComplexo) {
+      return {
+        fatias: ordenado.map((d, i) => ({ ...d, cor: CORES_SIMPLES[i % CORES_SIMPLES.length], ehOutros: false })),
+        total: totalGeral,
+        partidosOutros: [],
+      };
+    }
+
+    const principais = ordenado.slice(0, TOP_N);
+    const resto = ordenado.slice(TOP_N);
+    const lista = principais.map((d, i) => ({ ...d, cor: COR_BASE[i % COR_BASE.length], ehOutros: false }));
+
+    let restoDetalhado = [];
+    if (resto.length > 0) {
+      const totalResto = resto.reduce((acc, d) => acc + d.total, 0);
+      restoDetalhado = resto;
+      lista.push({ label: `Outros (${resto.length})`, total: totalResto, cor: COR_OUTROS, ehOutros: true });
+    }
+
+    return { fatias: lista, total: totalGeral, partidosOutros: restoDetalhado };
+  }, [dados, layoutComplexo]);
+
+  const coresGrafico = layoutComplexo ? fatias.map((f) => f.cor) : CORES_SIMPLES;
+
+  return (
+    <div
+      ref={chartRef}
+      className={`flex gap-8 ${layoutComplexo ? 'grid grid-cols-1 lg:grid-cols-[300px_1fr] items-center justify-items-center' : 'flex-col lg:flex-row items-center justify-center'}`}
+    >
       <div style={{ width: 300, height: 350, flexShrink: 0 }}>
         <PieChart width={300} height={350}>
           <Pie
-            data={dados}
+            data={fatias}
             dataKey="total"
             nameKey="label"
             cx="50%"
             cy="50%"
             outerRadius={140}
             isAnimationActive={true}
+            onMouseEnter={(_, index) => setAtivo(index)}
+            onMouseLeave={() => setAtivo(null)}
           >
-            {dados.map((_, index) => (
-              <Cell key={index} fill={CORES[index % CORES.length]} />
+            {fatias.map((item, index) => (
+              <Cell
+                key={item.label}
+                fill={layoutComplexo ? item.cor : coresGrafico[index % coresGrafico.length]}
+                opacity={ativo === null || ativo === index ? 1 : 0.35}
+                style={{ transition: 'opacity 0.15s' }}
+              />
             ))}
           </Pie>
           <Tooltip
@@ -33,23 +172,11 @@ export default function GraficoPizza({ dados, chartRef }) {
         </PieChart>
       </div>
 
-      {/* Legenda lateral */}
-      <div className="flex flex-col gap-3 min-w-48">
-        {dados.map((item, index) => (
-          <div key={item.label} className="flex items-center gap-3">
-            <div
-              className="w-3 h-3 rounded-full flex-shrink-0"
-              style={{ backgroundColor: CORES[index % CORES.length] }}
-            />
-            <div>
-              <p className="text-sm font-semibold text-gray-800">{item.label}</p>
-              <p className="text-xs text-gray-500">
-                {item.total.toLocaleString('pt-BR')} ({((item.total / total) * 100).toFixed(1)}%)
-              </p>
-            </div>
-          </div>
-        ))}
-      </div>
+      {layoutComplexo ? (
+        <LegendaCompleta fatias={fatias} total={total} partidosOutros={partidosOutros} ativo={ativo} setAtivo={setAtivo} />
+      ) : (
+        <LegendaSimples dados={fatias} total={total} ativo={ativo} setAtivo={setAtivo} />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Graficos/CardCTADashboard.jsx
+++ b/frontend/src/components/Graficos/CardCTADashboard.jsx
@@ -2,22 +2,15 @@ import { useNavigate } from 'react-router-dom';
 
 export default function CardCTADashboard() {
   const navigate = useNavigate();
-
   return (
-    <div className="bg-white border border-gray-200 border-l-4 border-l-[#5B4FCF] rounded-xl p-6 flex flex-col items-center text-center justify-center gap-4">
+    <div className="bg-white border border-gray-200 border-l-4 border-l-[#5B4FCF] rounded-xl p-6 h-full flex flex-col items-center text-center justify-center gap-4">
       <div className="w-12 h-12 rounded-full bg-purple-100 flex items-center justify-center">
         <span className="text-xl">📊</span>
       </div>
-
       <div>
-        <h3 className="text-base font-bold text-gray-800 mb-1">
-          Quer explorar os dados em detalhes?
-        </h3>
-        <p className="text-sm text-gray-500 leading-relaxed">
-          Acesse o painel completo com gráficos, filtros e rankings legislativos.
-        </p>
+        <h3 className="text-base font-bold text-gray-800 mb-1">Quer explorar os dados em detalhes?</h3>
+        <p className="text-sm text-gray-500 leading-relaxed">Acesse o painel completo com gráficos, filtros e rankings legislativos.</p>
       </div>
-
       <button
         onClick={() => navigate('/graficos/dashboard')}
         className="flex items-center gap-2 px-5 py-2.5 bg-[#5B4FCF] hover:bg-[#4338CA] text-white text-sm font-semibold rounded-lg transition-colors"

--- a/frontend/src/components/Graficos/CardParlamentaresAtivos.jsx
+++ b/frontend/src/components/Graficos/CardParlamentaresAtivos.jsx
@@ -6,42 +6,28 @@ const CORES_AVATAR = [
 
 export default function CardParlamentaresAtivos({ parlamentares }) {
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-5">
+    <div className="bg-white border border-gray-200 rounded-xl p-5 h-full">
       <h3 className="text-sm font-semibold text-gray-800 mb-4 flex items-center gap-2">
         👥 Parlamentares Ativos
       </h3>
-
       <div className="space-y-4">
         {parlamentares.map((p, index) => (
           <div key={p.nome} className="flex items-start gap-3">
-            {/* Avatar */}
             <div className={`w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 ${CORES_AVATAR[index % CORES_AVATAR.length]}`}>
               {p.iniciais}
             </div>
-
-            {/* Info */}
             <div className="flex-1 min-w-0">
               <div className="flex items-start justify-between gap-2">
                 <p className="text-sm font-semibold text-gray-800 leading-tight">{p.nome}</p>
-                <span className="text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded flex-shrink-0">
-                  {p.uf}
-                </span>
+                <span className="text-xs bg-gray-100 text-gray-500 px-1.5 py-0.5 rounded flex-shrink-0">{p.uf}</span>
               </div>
               <div className="flex items-center justify-between mt-0.5">
                 <p className="text-xs text-gray-400">{p.descricao}</p>
-                <span className="text-xs font-bold text-[#5B4FCF]">
-                  {p.total_propostas} prop.
-                </span>
+                <span className="text-xs font-bold text-[#5B4FCF]">{p.total_propostas} prop.</span>
               </div>
             </div>
           </div>
         ))}
-      </div>
-
-      <div className="mt-4 pt-3 border-t border-gray-100 text-center">
-        <button className="text-sm font-semibold text-[#5B4FCF] hover:text-[#4338CA] transition-colors">
-          Ver todos →
-        </button>
       </div>
     </div>
   );

--- a/frontend/src/components/Graficos/CardTempoTramitacao.jsx
+++ b/frontend/src/components/Graficos/CardTempoTramitacao.jsx
@@ -7,25 +7,25 @@ export default function CardTempoTramitacao({ dados }) {
   const badge = BADGE_CONFIG[dados.tendencia] ?? BADGE_CONFIG.aumento;
 
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-6 relative flex flex-col items-center text-center h-full">
-      <span className="absolute top-5 right-5 text-4xl opacity-20 select-none">⏳</span>
+    <div className="bg-white border border-gray-200 rounded-xl p-6 relative flex flex-col items-center text-center justify-center h-full">
+      <span className="absolute top-5 right-5 text-5xl opacity-20 select-none">⏳</span>
 
-      <h2 className="text-base font-semibold text-gray-700 mb-4">
+      <h2 className="text-xl font-semibold text-gray-700 mb-1">
         Tempo Médio de Tramitação
       </h2>
 
-      <div className="flex items-baseline gap-2 mb-2">
-        <span className="text-5xl font-bold text-[#5B4FCF]">
-          {dados.dias.toLocaleString('pt-BR')}
-        </span>
-        <span className="text-lg text-gray-400">dias</span>
-      </div>
-
-      <p className="text-sm text-gray-500 mb-4">
-        úteis em média para PLs de feminicídio
+      <p className="text-sm text-gray-400 mb-6">
+        nos últimos 12 meses
       </p>
 
-      <span className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium ${badge.bg} ${badge.texto}`}>
+      <div className="flex items-baseline gap-3 mb-6">
+        <span className="text-7xl font-bold text-[#5B4FCF]">
+          {dados.dias.toLocaleString('pt-BR')}
+        </span>
+        <span className="text-2xl text-gray-400">dias</span>
+      </div>
+
+      <span className={`inline-flex items-center gap-1 px-4 py-1.5 rounded-full text-base font-medium ${badge.bg} ${badge.texto}`}>
         {badge.icone} {badge.sinal}{dados.variacao_percentual}% vs ano anterior
       </span>
     </div>

--- a/frontend/src/components/Graficos/CardTempoTramitacao.jsx
+++ b/frontend/src/components/Graficos/CardTempoTramitacao.jsx
@@ -7,27 +7,29 @@ export default function CardTempoTramitacao({ dados }) {
   const badge = BADGE_CONFIG[dados.tendencia] ?? BADGE_CONFIG.aumento;
 
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-6 relative flex flex-col items-center text-center justify-center h-full">
-      <span className="absolute top-5 right-5 text-5xl opacity-20 select-none">⏳</span>
-
-      <h2 className="text-xl font-semibold text-gray-700 mb-1">
-        Tempo Médio de Tramitação
-      </h2>
-
-      <p className="text-sm text-gray-400 mb-6">
-        nos últimos 12 meses
-      </p>
-
-      <div className="flex items-baseline gap-3 mb-6">
-        <span className="text-7xl font-bold text-[#5B4FCF]">
-          {dados.dias.toLocaleString('pt-BR')}
+    <div className="bg-white border border-gray-200 rounded-xl p-6 relative flex flex-col h-full">
+      {/* Header alinhado à esquerda, igual aos outros cards */}
+      <div className="flex items-start justify-between mb-1">
+        <div className="flex items-center gap-2">
+          <span className="text-[#5B4FCF] text-lg">⏳</span>
+          <h2 className="text-base font-semibold text-gray-700">
+            Tempo Médio de Tramitação
+          </h2>
+        </div>
+        <span className="text-xs font-medium text-[#5B4FCF] bg-[#5B4FCF]/10 px-2.5 py-1 rounded-md">
+           Geral
         </span>
-        <span className="text-2xl text-gray-400">dias</span>
       </div>
 
-      <span className={`inline-flex items-center gap-1 px-4 py-1.5 rounded-full text-base font-medium ${badge.bg} ${badge.texto}`}>
-        {badge.icone} {badge.sinal}{dados.variacao_percentual}% vs ano anterior
-      </span>
+      {/* Número centralizado, ocupando o corpo do card */}
+      <div className="flex-1 flex items-center justify-center">
+        <div className="flex items-baseline gap-3">
+          <span className="text-7xl font-bold text-[#5B4FCF]">
+            {dados.dias.toLocaleString('pt-BR')}
+          </span>
+          <span className="text-2xl text-gray-400">dias</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Graficos/CardTopEstados.jsx
+++ b/frontend/src/components/Graficos/CardTopEstados.jsx
@@ -1,30 +1,21 @@
 export default function CardTopEstados({ estados }) {
   const maxPls = Math.max(...estados.map((e) => e.total_pls));
-
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-5">
+    <div className="bg-white border border-gray-200 rounded-xl p-5 h-full">
       <h3 className="text-sm font-semibold text-gray-800 mb-4 flex items-center gap-2">
         📈 Top 5 Estados
       </h3>
-
       <div className="space-y-4">
         {estados.map((estado) => {
           const largura = Math.round((estado.total_pls / maxPls) * 100);
           return (
             <div key={estado.uf}>
               <div className="flex items-center justify-between mb-1">
-                <span className="text-sm text-gray-700">
-                  {estado.estado} ({estado.uf})
-                </span>
-                <span className="text-sm font-bold text-[#5B4FCF]">
-                  {estado.total_pls.toLocaleString('pt-BR')} PLs
-                </span>
+                <span className="text-sm text-gray-700">{estado.estado} ({estado.uf})</span>
+                <span className="text-sm font-bold text-[#5B4FCF]">{estado.total_pls.toLocaleString('pt-BR')} PLs</span>
               </div>
               <div className="w-full bg-gray-100 rounded-full h-1.5">
-                <div
-                  className="bg-[#5B4FCF] h-1.5 rounded-full transition-all duration-500"
-                  style={{ width: `${largura}%` }}
-                />
+                <div className="bg-[#5B4FCF] h-1.5 rounded-full transition-all duration-500" style={{ width: `${largura}%` }} />
               </div>
             </div>
           );

--- a/frontend/src/pages/Dashboard/index.jsx
+++ b/frontend/src/pages/Dashboard/index.jsx
@@ -47,7 +47,6 @@ export default function Dashboard() {
       <main className="flex-1 max-w-7xl mx-auto w-full px-6 py-10">
         <BreadcrumbDashboard />
 
-        {/* Header */}
         <div className="mb-6">
           <h1 className="text-3xl font-bold text-gray-900 uppercase mb-1">
             Painel de Dados Legislativos
@@ -58,20 +57,16 @@ export default function Dashboard() {
           </p>
         </div>
 
-        {/* Seletor Comparar por */}
         <SeletorComparar ativo={compararPor} onChange={mudarComparar} />
 
-        {/* Filtros */}
         <FiltrosDashboard
           compararPor={compararPor}
           filtros={filtros}
           onChange={mudarFiltro}
         />
 
-        {/* Cards de indicadores */}
         <CardIndicadores indicadores={dados?.indicadores} loading={loading} />
 
-        {/* Área do gráfico */}
         {error ? (
           <div className="flex flex-col items-center justify-center py-16 gap-4">
             <p className="text-gray-500 text-center text-sm">
@@ -86,7 +81,6 @@ export default function Dashboard() {
           </div>
         ) : (
           <div className="bg-white border border-gray-200 rounded-xl p-6">
-            {/* Cabeçalho da área do gráfico */}
             <div className="flex items-center justify-between mb-5">
               <div className="flex gap-1">
                 {['colunas', 'pizza'].map((aba) => (
@@ -109,7 +103,6 @@ export default function Dashboard() {
               />
             </div>
 
-            {/* Título e data */}
             <div className="flex items-start justify-between mb-4">
               <h2 className="text-base font-semibold text-gray-800">
                 Distribuição de PLs por {LABELS_DIMENSAO[compararPor]}
@@ -121,7 +114,6 @@ export default function Dashboard() {
               )}
             </div>
 
-            {/* Gráfico */}
             {loading ? (
               <SkeletonGrafico />
             ) : !dados?.dados?.length ? (
@@ -133,7 +125,11 @@ export default function Dashboard() {
             ) : abaAtiva === 'colunas' ? (
               <GraficoColunas dados={dados.dados} chartRef={chartRef} />
             ) : (
-              <GraficoPizza dados={dados.dados} chartRef={chartRef} />
+              <GraficoPizza
+                dados={dados.dados}
+                chartRef={chartRef}
+                compararPor={compararPor}
+              />
             )}
           </div>
         )}

--- a/frontend/src/pages/Graficos/index.jsx
+++ b/frontend/src/pages/Graficos/index.jsx
@@ -12,14 +12,10 @@ function SkeletonGraficos() {
       <div className="h-8 bg-gray-200 rounded w-96 mb-2" />
       <div className="h-4 bg-gray-200 rounded w-72 mb-8" />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <div className="flex flex-col gap-6">
-          <div className="bg-white border border-gray-200 rounded-xl p-6 h-44" />
-          <div className="bg-white border border-gray-200 rounded-xl p-6 h-32" />
-        </div>
-        <div className="flex flex-col gap-6">
-          <div className="bg-white border border-gray-200 rounded-xl p-5 h-56" />
-          <div className="bg-white border border-gray-200 rounded-xl p-5 h-52" />
-        </div>
+        <div className="bg-white border border-gray-200 rounded-xl p-6 h-64" />
+        <div className="bg-white border border-gray-200 rounded-xl p-5 h-64" />
+        <div className="bg-white border border-gray-200 rounded-xl p-6 h-64" />
+        <div className="bg-white border border-gray-200 rounded-xl p-5 h-64" />
       </div>
     </div>
   );
@@ -60,18 +56,21 @@ export default function Graficos() {
               </p>
             </div>
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              {/* Coluna esquerda */}
-              <div className="flex flex-col gap-6">
+            {/* Grid 2x2 com todas as células de altura igual */}
+            <div
+              className="grid grid-cols-1 lg:grid-cols-2 gap-6"
+              style={{ gridAutoRows: '1fr' }}
+            >
+              <div className="h-full">
                 <CardParlamentaresAtivos parlamentares={dados.parlamentares_ativos} />
-                <div className="flex-1">
-                  <CardTempoTramitacao dados={dados.tempo_medio_tramitacao} />
-                </div>
               </div>
-
-              {/* Coluna direita */}
-              <div className="flex flex-col gap-6">
+              <div className="h-full">
                 <CardTopEstados estados={dados.top_estados} />
+              </div>
+              <div className="h-full">
+                <CardTempoTramitacao dados={dados.tempo_medio_tramitacao} />
+              </div>
+              <div className="h-full">
                 <CardCTADashboard />
               </div>
             </div>


### PR DESCRIPTION
## O que foi feito
Melhorias visuais nas páginas de Gráficos e Dashboard após revisão da Release 2.

## Mudanças

### Página de Gráficos
- Removido botão "Ver todos" do card de Parlamentares Ativos
- Card de Tempo Médio de Tramitação: nova ordem dos textos, subtítulo "nos últimos 12 meses", fontes aumentadas e conteúdo centralizado
- Layout dos 4 cards ajustado para ficarem simétricos (grid 2x2 com altura igual)

### Dashboard — Gráfico de Colunas
- Labels do eixo X rotacionados em -45° para exibir nomes longos sem cortar
- Todos os labels exibidos sem pular (`interval={0}`)

### Dashboard — Gráfico de Pizza
- Layout duplo conforme a dimensão selecionada:
  - **Partido / Estado:** legenda em 2 colunas com agrupamento "Outros" expansível
  - **Gênero / Mês:** legenda vertical simples centralizada
- Prop `compararPor` adicionada ao componente `GraficoPizza`

## Como testar
1. `docker-compose up --build`
2. Acessar `http://localhost:5173/graficos` e verificar os cards
3. Acessar `http://localhost:5173/graficos/dashboard`
4. Alternar entre Partido, Estado, Gênero e Mês no gráfico de Pizza e verificar os layouts diferentes