### PR TITLE
fix: corrige erros de linter (ruff) no backend

### DIFF
--- a/backend/app/migrations/versions/baf79178346c_criando_tabelas_iniciais.py
+++ b/backend/app/migrations/versions/baf79178346c_criando_tabelas_iniciais.py
@@ -9,7 +9,6 @@ from typing import Sequence, Union
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects import postgresql
 
 revision: str = 'baf79178346c'

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -28,10 +28,10 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
+from sqlalchemy.orm import DeclarativeBase, relationship
 from sqlalchemy.types import JSON
 
 JSONB = PG_JSONB().with_variant(JSON, "sqlite")
-from sqlalchemy.orm import DeclarativeBase, relationship
 
 
 class Base(DeclarativeBase):
@@ -56,10 +56,13 @@ class PlSenado(Base):
     tramitando = Column(Boolean, nullable=True)
     sigla_tipo_deliberacao = Column(String, nullable=True)
     dados_raw = Column(JSONB, nullable=True)                          # ADR-002
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    created_at = Column(DateTime(timezone=True),
+                        server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(
+    ), onupdate=func.now(), nullable=False)
 
-    autorias = relationship("AutoriaSenado", back_populates="pl", cascade="all, delete-orphan")
+    autorias = relationship(
+        "AutoriaSenado", back_populates="pl", cascade="all, delete-orphan")
     tramitacoes = relationship("TramitacaoSenado", back_populates="pl", cascade="all, delete-orphan",
                                order_by="TramitacaoSenado.sequencia")
 
@@ -82,10 +85,13 @@ class PlCamara(Base):
     descricao_situacao = Column(String, nullable=True)
     despacho = Column(Text, nullable=True)
     dados_raw = Column(JSONB, nullable=True)                          # ADR-002
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    created_at = Column(DateTime(timezone=True),
+                        server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(
+    ), onupdate=func.now(), nullable=False)
 
-    autorias = relationship("AutoriaCamara", back_populates="pl", cascade="all, delete-orphan")
+    autorias = relationship(
+        "AutoriaCamara", back_populates="pl", cascade="all, delete-orphan")
     tramitacoes = relationship("TramitacaoCamara", back_populates="pl", cascade="all, delete-orphan",
                                order_by="TramitacaoCamara.sequencia")
 
@@ -97,24 +103,31 @@ class PlCamara(Base):
 class Parlamentar(Base):
     __tablename__ = "parlamentares"
     __table_args__ = (
-        CheckConstraint("casa IN ('Câmara', 'Senado')", name="ck_parlamentares_casa"),
+        CheckConstraint("casa IN ('Câmara', 'Senado')",
+                        name="ck_parlamentares_casa"),
         CheckConstraint("sexo IN ('F', 'M')", name="ck_parlamentares_sexo"),
     )
 
-    id = Column(String, primary_key=True, nullable=False)             # "cam_141492" ou "sen_5783"
+    # "cam_141492" ou "sen_5783"
+    id = Column(String, primary_key=True, nullable=False)
     casa = Column(String, nullable=False)
     nome_eleitoral = Column(String, nullable=False)
     nome_civil = Column(String, nullable=True)
     sigla_partido = Column(String, nullable=False)
     sigla_uf = Column(String(2), nullable=True)
-    sexo = Column(String(1), nullable=False)                          # "F" ou "M"
+    # "F" ou "M"
+    sexo = Column(String(1), nullable=False)
     url_foto = Column(String, nullable=True)
     status_mandato = Column(String, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    created_at = Column(DateTime(timezone=True),
+                        server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(
+    ), onupdate=func.now(), nullable=False)
 
-    autorias_camara = relationship("AutoriaCamara", back_populates="parlamentar")
-    autorias_senado = relationship("AutoriaSenado", back_populates="parlamentar")
+    autorias_camara = relationship(
+        "AutoriaCamara", back_populates="parlamentar")
+    autorias_senado = relationship(
+        "AutoriaSenado", back_populates="parlamentar")
 
 
 # ---------------------------------------------------------------------------
@@ -124,8 +137,10 @@ class Parlamentar(Base):
 class AutoriaCamara(Base):
     __tablename__ = "autoria_camara"
 
-    id_pl = Column(Integer, ForeignKey("pls_camara.id", ondelete="CASCADE"), primary_key=True, nullable=False)
-    id_parlamentar = Column(String, ForeignKey("parlamentares.id", ondelete="CASCADE"), primary_key=True, nullable=False)
+    id_pl = Column(Integer, ForeignKey("pls_camara.id",
+                   ondelete="CASCADE"), primary_key=True, nullable=False)
+    id_parlamentar = Column(String, ForeignKey(
+        "parlamentares.id", ondelete="CASCADE"), primary_key=True, nullable=False)
     tipo_autoria = Column(String, nullable=True)
 
     pl = relationship("PlCamara", back_populates="autorias")
@@ -135,8 +150,10 @@ class AutoriaCamara(Base):
 class AutoriaSenado(Base):
     __tablename__ = "autoria_senado"
 
-    id_pl = Column(Integer, ForeignKey("pls_senado.id", ondelete="CASCADE"), primary_key=True, nullable=False)
-    id_parlamentar = Column(String, ForeignKey("parlamentares.id", ondelete="CASCADE"), primary_key=True, nullable=False)
+    id_pl = Column(Integer, ForeignKey("pls_senado.id",
+                   ondelete="CASCADE"), primary_key=True, nullable=False)
+    id_parlamentar = Column(String, ForeignKey(
+        "parlamentares.id", ondelete="CASCADE"), primary_key=True, nullable=False)
     tipo_autoria = Column(String, nullable=True)
 
     pl = relationship("PlSenado", back_populates="autorias")
@@ -151,14 +168,16 @@ class TramitacaoSenado(Base):
     __tablename__ = "tramitacao_senado"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    id_pl = Column(Integer, ForeignKey("pls_senado.id", ondelete="CASCADE"), nullable=False)
+    id_pl = Column(Integer, ForeignKey("pls_senado.id",
+                   ondelete="CASCADE"), nullable=False)
     data_tramitacao = Column(Date, nullable=True)
     situacao = Column(String, nullable=True)
     descricao = Column(Text, nullable=True)
     local = Column(String, nullable=True)
     sequencia = Column(Integer, nullable=True)
     dados_raw = Column(JSONB, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    created_at = Column(DateTime(timezone=True),
+                        server_default=func.now(), nullable=False)
 
     pl = relationship("PlSenado", back_populates="tramitacoes")
 
@@ -167,13 +186,15 @@ class TramitacaoCamara(Base):
     __tablename__ = "tramitacao_camara"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    id_pl = Column(Integer, ForeignKey("pls_camara.id", ondelete="CASCADE"), nullable=False)
+    id_pl = Column(Integer, ForeignKey("pls_camara.id",
+                   ondelete="CASCADE"), nullable=False)
     data_tramitacao = Column(DateTime(timezone=True), nullable=True)
     situacao = Column(String, nullable=True)
     descricao = Column(Text, nullable=True)
     local = Column(String, nullable=True)
     sequencia = Column(Integer, nullable=True)
     dados_raw = Column(JSONB, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    created_at = Column(DateTime(timezone=True),
+                        server_default=func.now(), nullable=False)
 
     pl = relationship("PlCamara", back_populates="tramitacoes")

--- a/backend/app/routers/projeto.py
+++ b/backend/app/routers/projeto.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
-from sqlalchemy import select, func, and_, or_, cast, String, Integer, null, case
+from sqlalchemy import select, func, or_, cast, String, Integer, null, case
 from app.database import get_db
 from app.models import (
     PlCamara, PlSenado, Parlamentar, AutoriaCamara, AutoriaSenado,
@@ -255,7 +255,6 @@ def listar_projetos(
 
 @router.get("/{casa}/{numero}/{ano}")
 def obter_projeto_detalhado(casa: str, numero: str, ano: int, db: Session = Depends(get_db)):
-    from app.services.normalizer import normalizar_status_camara, normalizar_status_senado
     casa_low = casa.lower()
     
     if casa_low in ["camara", "câmara", "camara dos deputados", "câmara dos deputados"]:

--- a/backend/app/services/camara_client.py
+++ b/backend/app/services/camara_client.py
@@ -9,6 +9,7 @@ Base URL: https://dadosabertos.camara.leg.br/api/v2
 """
 
 import logging
+from datetime import date, timedelta
 from typing import Any, Iterator, Optional
 import requests
 
@@ -28,6 +29,7 @@ SIGLAS_TIPO = ["PL", "PLP"]
 
 _cache_deputados = {}
 
+
 def _get(path: str, params: Optional[dict] = None) -> Optional[dict[str, Any]]:
     url = f"{BASE_URL}/{path.lstrip('/')}"
     try:
@@ -38,7 +40,6 @@ def _get(path: str, params: Optional[dict] = None) -> Optional[dict[str, Any]]:
         logger.warning("Câmara API indisponível [%s]: %s", url, exc)
         return None
 
-from datetime import date, timedelta
 
 def listar_proposicoes(
     sigla_tipo: str,
@@ -79,11 +80,13 @@ def listar_proposicoes(
             break
         pagina += 1
 
+
 def buscar_detalhe(id_proposicao: int) -> Optional[dict[str, Any]]:
     raw = _get(f"/proposicoes/{id_proposicao}")
     if not raw:
         return None
     return raw.get("dados")
+
 
 def buscar_autores(id_proposicao: int) -> list[dict[str, Any]]:
     raw = _get(f"/proposicoes/{id_proposicao}/autores")
@@ -91,21 +94,23 @@ def buscar_autores(id_proposicao: int) -> list[dict[str, Any]]:
         return []
     return raw.get("dados", [])
 
+
 def buscar_tramitacoes(id_proposicao: int) -> list[dict[str, Any]]:
     raw = _get(f"/proposicoes/{id_proposicao}/tramitacoes")
     if not raw:
         return []
     return raw.get("dados", [])
 
+
 def buscar_deputado(id_deputado: int) -> Optional[dict[str, Any]]:
     id_str = str(id_deputado)
     if id_str in _cache_deputados:
         return _cache_deputados[id_str]
-        
+
     raw = _get(f"/deputados/{id_str}")
     if not raw:
         return None
-        
+
     dados = raw.get("dados", {})
     _cache_deputados[id_str] = dados
     return dados

--- a/backend/app/services/collector.py
+++ b/backend/app/services/collector.py
@@ -4,14 +4,10 @@ app/services/collector.py
 Orquestrador de coleta: coordena clientes HTTP → schemas → normalizer → banco.
 """
 
-import asyncio
 import logging
-from datetime import date
 from typing import Optional
-import time
 from sqlalchemy.orm import Session
 
-from app import services  
 from app.services import camara_client, senado_client
 from app.services.normalizer import (
     upsert_autores_camara,

--- a/backend/app/services/graficos.py
+++ b/backend/app/services/graficos.py
@@ -63,7 +63,8 @@ def _base_proposicoes():
         select(
             literal("camara").label("casa"),
             PlCamara.id.label("id_pl"),
-            func.concat(literal("camara:"), cast(PlCamara.id, String)).label("proposicao_id"),
+            func.concat(literal("camara:"), cast(
+                PlCamara.id, String)).label("proposicao_id"),
             PlCamara.data_apresentacao.label("data_apresentacao"),
             PlCamara.updated_at.label("data_atualizacao"),
             Parlamentar.sigla_partido.label("partido"),
@@ -78,7 +79,8 @@ def _base_proposicoes():
         select(
             literal("senado").label("casa"),
             PlSenado.id.label("id_pl"),
-            func.concat(literal("senado:"), cast(PlSenado.id, String)).label("proposicao_id"),
+            func.concat(literal("senado:"), cast(
+                PlSenado.id, String)).label("proposicao_id"),
             PlSenado.data_apresentacao.label("data_apresentacao"),
             PlSenado.updated_at.label("data_atualizacao"),
             Parlamentar.sigla_partido.label("partido"),
@@ -117,7 +119,8 @@ def _aplicar_filtros(query, base, comparar_por: str, filtros: dict):
             query = query.where(base.c.sexo == sexo)
 
     if mes and comparar_por != "mes":
-        query = query.where(cast(func.extract("month", base.c.data_apresentacao), Integer) == mes)
+        query = query.where(
+            cast(func.extract("month", base.c.data_apresentacao), Integer) == mes)
 
     return query
 
@@ -162,10 +165,12 @@ def _agregar_por_dimensao(db: Session, base, comparar_por: str, filtros: dict):
 
     label_col = _coluna_agrupamento(base, comparar_por).label("label")
 
-    query = select(label_col, func.count(func.distinct(base.c.proposicao_id)).label("total")).select_from(base)
+    query = select(label_col, func.count(func.distinct(
+        base.c.proposicao_id)).label("total")).select_from(base)
     query = _aplicar_filtros(query, base, comparar_por, filtros)
     query = _aplicar_label_preenchido(query, label_col, comparar_por)
-    query = query.group_by(label_col).order_by(func.count(func.distinct(base.c.proposicao_id)).desc())
+    query = query.group_by(label_col).order_by(
+        func.count(func.distinct(base.c.proposicao_id)).desc())
 
     dados = []
     for row in db.execute(query).all():
@@ -178,7 +183,8 @@ def _agregar_por_dimensao(db: Session, base, comparar_por: str, filtros: dict):
 def _total_pls(db: Session, base, comparar_por: str, filtros: dict) -> int:
     """Calcula o total de registros considerados após os filtros válidos."""
 
-    query = select(func.count(func.distinct(base.c.proposicao_id))).select_from(base)
+    query = select(func.count(func.distinct(
+        base.c.proposicao_id))).select_from(base)
     query = _aplicar_filtros(query, base, comparar_por, filtros)
     return db.execute(query).scalar() or 0
 
@@ -187,10 +193,12 @@ def _mais_ativo(db: Session, base, comparar_por: str, filtros: dict, campo: str)
     """Calcula o partido ou estado com mais propostas após os filtros."""
 
     label_col = func.upper(getattr(base.c, campo)).label("label")
-    query = select(label_col, func.count(func.distinct(base.c.proposicao_id)).label("total")).select_from(base)
+    query = select(label_col, func.count(func.distinct(
+        base.c.proposicao_id)).label("total")).select_from(base)
     query = _aplicar_filtros(query, base, comparar_por, filtros)
     query = query.where(label_col.isnot(None), label_col != "")
-    query = query.group_by(label_col).order_by(func.count(func.distinct(base.c.proposicao_id)).desc()).limit(1)
+    query = query.group_by(label_col).order_by(func.count(
+        func.distinct(base.c.proposicao_id)).desc()).limit(1)
 
     row = db.execute(query).first()
     return row.label if row else None
@@ -215,7 +223,8 @@ def obter_distribuicao(
     """Orquestra todos os cálculos exigidos por GET /api/graficos/distribuicao."""
 
     base = _base_proposicoes()
-    filtros = {"estado": estado, "partido": partido, "genero": genero, "mes": mes}
+    filtros = {"estado": estado, "partido": partido,
+               "genero": genero, "mes": mes}
 
     return {
         "comparar_por": comparar_por,
@@ -228,49 +237,54 @@ def obter_distribuicao(
         "dados": _agregar_por_dimensao(db, base, comparar_por, filtros),
     }
 
+
 def obter_resumo(db: Session) -> dict:
     from app.models import TramitacaoCamara, TramitacaoSenado
     from datetime import datetime
-    
+
     # 1. Tempo Médio (Apenas Sancionados)
     query_camara = db.execute(
-        select(PlCamara.data_apresentacao, func.max(TramitacaoCamara.data_tramitacao))
+        select(PlCamara.data_apresentacao, func.max(
+            TramitacaoCamara.data_tramitacao))
         .outerjoin(TramitacaoCamara, TramitacaoCamara.id_pl == PlCamara.id)
         .where(PlCamara.descricao_situacao == "Transformado em Norma Jurídica")
         .group_by(PlCamara.id)
     ).all()
-    
+
     query_senado = db.execute(
-        select(PlSenado.data_apresentacao, func.max(TramitacaoSenado.data_tramitacao))
+        select(PlSenado.data_apresentacao, func.max(
+            TramitacaoSenado.data_tramitacao))
         .outerjoin(TramitacaoSenado, TramitacaoSenado.id_pl == PlSenado.id)
         .where(PlSenado.dados_raw['situacaoAtual'].astext.in_(['TNJR', 'TNJRVETO']))
         .group_by(PlSenado.id)
     ).all()
-    
+
     soma_dias = 0
     total_pls_tempo = 0
     hoje = datetime.now()
-    
+
     for dt_apresentacao, max_tramitacao in query_camara + query_senado:
-        if not dt_apresentacao: continue
+        if not dt_apresentacao:
+            continue
         dt_fim = max_tramitacao or hoje
-        
-        dt_a = dt_apresentacao.date() if isinstance(dt_apresentacao, datetime) else dt_apresentacao
+
+        dt_a = dt_apresentacao.date() if isinstance(
+            dt_apresentacao, datetime) else dt_apresentacao
         dt_f = dt_fim.date() if isinstance(dt_fim, datetime) else dt_fim
-        
+
         dias = max(0, (dt_f - dt_a).days)
         soma_dias += dias
         total_pls_tempo += 1
-            
+
     dias_medios = soma_dias // total_pls_tempo if total_pls_tempo else 0
-    
+
     # 2. Top Estados
     base = _base_proposicoes()
     query_estados = select(
         func.upper(base.c.estado).label("uf"),
         func.count(func.distinct(base.c.proposicao_id)).label("total_pls")
     ).where(base.c.estado.isnot(None), base.c.estado != "").group_by(func.upper(base.c.estado)).order_by(func.count(func.distinct(base.c.proposicao_id)).desc()).limit(5)
-    
+
     mapa_estados = {
         "AC": "Acre", "AL": "Alagoas", "AP": "Amapá", "AM": "Amazonas", "BA": "Bahia", "CE": "Ceará", "DF": "Distrito Federal",
         "ES": "Espírito Santo", "GO": "Goiás", "MA": "Maranhão", "MT": "Mato Grosso", "MS": "Mato Grosso do Sul",
@@ -278,7 +292,7 @@ def obter_resumo(db: Session) -> dict:
         "RJ": "Rio de Janeiro", "RN": "Rio Grande do Norte", "RS": "Rio Grande do Sul", "RO": "Rondônia", "RR": "Roraima",
         "SC": "Santa Catarina", "SP": "São Paulo", "SE": "Sergipe", "TO": "Tocantins"
     }
-    
+
     top_estados = []
     for row in db.execute(query_estados).all():
         top_estados.append({
@@ -286,7 +300,7 @@ def obter_resumo(db: Session) -> dict:
             "uf": row.uf,
             "total_pls": row.total_pls
         })
-        
+
     # 3. Parlamentares Ativos
     camara_parl = select(
         Parlamentar.nome_eleitoral.label("nome"),
@@ -296,7 +310,7 @@ def obter_resumo(db: Session) -> dict:
         literal("Câmara").label("casa"),
         func.count(func.distinct(AutoriaCamara.id_pl)).label("total")
     ).join(AutoriaCamara, AutoriaCamara.id_parlamentar == Parlamentar.id).group_by(Parlamentar.id)
-    
+
     senado_parl = select(
         Parlamentar.nome_eleitoral.label("nome"),
         Parlamentar.sigla_partido.label("partido"),
@@ -305,18 +319,20 @@ def obter_resumo(db: Session) -> dict:
         literal("Senado").label("casa"),
         func.count(func.distinct(AutoriaSenado.id_pl)).label("total")
     ).join(AutoriaSenado, AutoriaSenado.id_parlamentar == Parlamentar.id).group_by(Parlamentar.id)
-    
+
     query_parl = camara_parl.union_all(senado_parl).subquery()
     query_top_parl = select(
-        query_parl.c.nome, query_parl.c.partido, query_parl.c.uf, query_parl.c.sexo, query_parl.c.casa, func.sum(query_parl.c.total).label("total_propostas")
+        query_parl.c.nome, query_parl.c.partido, query_parl.c.uf, query_parl.c.sexo, query_parl.c.casa, func.sum(
+            query_parl.c.total).label("total_propostas")
     ).group_by(query_parl.c.nome, query_parl.c.partido, query_parl.c.uf, query_parl.c.sexo, query_parl.c.casa).order_by(func.sum(query_parl.c.total).desc()).limit(3)
-    
+
     parlamentares = []
     for row in db.execute(query_top_parl).all():
         cargo = "Deputado Federal" if row.casa == "Câmara" and row.sexo == "M" else "Deputada Federal" if row.casa == "Câmara" else "Senador" if row.sexo == "M" else "Senadora"
         nomes = row.nome.split()
-        iniciais = (nomes[0][0] + nomes[1][0]).upper() if len(nomes) > 1 else nomes[0][0:2].upper()
-        
+        iniciais = (nomes[0][0] + nomes[1][0]
+                    ).upper() if len(nomes) > 1 else nomes[0][0:2].upper()
+
         parlamentares.append({
             "nome": row.nome,
             "iniciais": iniciais,
@@ -324,7 +340,7 @@ def obter_resumo(db: Session) -> dict:
             "uf": row.uf,
             "total_propostas": row.total_propostas
         })
-        
+
     return {
         "tempo_medio_tramitacao": {
             "dias": dias_medios

--- a/backend/app/services/normalizer.py
+++ b/backend/app/services/normalizer.py
@@ -13,10 +13,12 @@ from app.models import PlCamara, PlSenado, AutoriaCamara, AutoriaSenado, Tramita
 
 logger = logging.getLogger(__name__)
 
+
 def higienizar_para_jsonb(dados: Any) -> Any:
     if dados is None:
         return None
     return json.loads(json.dumps(dados, default=str))
+
 
 def limpar_sexo(raw_sexo: Any) -> str:
     """Garante que o sexo será sempre 'M' ou 'F' (1 caractere) para o banco."""
@@ -29,64 +31,76 @@ def limpar_sexo(raw_sexo: Any) -> str:
 # UPSERTS DA CÂMARA DOS DEPUTADOS
 # ---------------------------------------------------------------------------
 
+
 def extrair_lista_camara(payload: Any) -> List[Dict]:
-    if isinstance(payload, dict): return payload.get("dados", [])
-    elif isinstance(payload, list): return payload
+    if isinstance(payload, dict):
+        return payload.get("dados", [])
+    elif isinstance(payload, list):
+        return payload
     return []
 
+
 def extrair_dict_camara(payload: Any) -> Dict:
-    if isinstance(payload, dict): return payload.get("dados", payload)
+    if isinstance(payload, dict):
+        return payload.get("dados", payload)
     elif isinstance(payload, list) and len(payload) > 0:
         return payload[0] if isinstance(payload[0], dict) else {}
     return {}
+
 
 def upsert_pl_camara(session: Session, item_raw: Dict, detalhe_raw: Optional[Dict], dados_originais: Dict) -> Optional[int]:
     try:
         raw_limpo = higienizar_para_jsonb(dados_originais)
         item = extrair_dict_camara(item_raw)
         detalhe = extrair_dict_camara(detalhe_raw) if detalhe_raw else {}
-        
+
         pl_id = item.get("id")
-        if not pl_id: return None
-            
+        if not pl_id:
+            return None
+
         proposicao = detalhe if detalhe else item
         status_info = proposicao.get("statusProposicao", {})
-        if isinstance(status_info, list): status_info = status_info[0] if status_info else {}
-            
+        if isinstance(status_info, list):
+            status_info = status_info[0] if status_info else {}
+
         nova_pl = PlCamara(
-             id=int(pl_id),
-             numero=int(proposicao.get("numero", 0)),
-             ano=int(proposicao.get("ano")) if proposicao.get("ano") else None,
-             sigla_tipo=proposicao.get("siglaTipo"),
-             uri=proposicao.get("uri"),
-             data_apresentacao=proposicao.get("dataApresentacao"),
-             ementa=proposicao.get("ementa", ""),
-             descricao_tipo=proposicao.get("descricaoTipo"),
-             descricao_situacao=status_info.get("descricaoSituacao"),
-             despacho=status_info.get("despacho"),
-             dados_raw=raw_limpo
-         )
+            id=int(pl_id),
+            numero=int(proposicao.get("numero", 0)),
+            ano=int(proposicao.get("ano")) if proposicao.get("ano") else None,
+            sigla_tipo=proposicao.get("siglaTipo"),
+            uri=proposicao.get("uri"),
+            data_apresentacao=proposicao.get("dataApresentacao"),
+            ementa=proposicao.get("ementa", ""),
+            descricao_tipo=proposicao.get("descricaoTipo"),
+            descricao_situacao=status_info.get("descricaoSituacao"),
+            despacho=status_info.get("despacho"),
+            dados_raw=raw_limpo
+        )
         session.merge(nova_pl)
         return int(pl_id)
     except Exception as exc:
         logger.error("Erro no upsert_pl_camara: %s", exc)
         return None
 
+
 def upsert_autores_camara(session: Session, id_pl: int, autores_raw: Any) -> None:
     try:
         autores_limpos = higienizar_para_jsonb(autores_raw)
         lista_autores = extrair_lista_camara(autores_limpos)
-        
+
         for autor in lista_autores:
-            if not isinstance(autor, dict): continue 
-                
+            if not isinstance(autor, dict):
+                continue
+
             uri = autor.get("uri")
-            if not uri: continue
-            
+            if not uri:
+                continue
+
             try:
                 parl_id_api = uri.rstrip("/").split("/")[-1]
                 parlamentar_id = f"cam_{parl_id_api}"
-            except Exception: continue
+            except Exception:
+                continue
 
             detalhes = autor.get("detalhes_deputado", {})
             ultimo_status = detalhes.get("ultimoStatus", {})
@@ -94,10 +108,12 @@ def upsert_autores_camara(session: Session, id_pl: int, autores_raw: Any) -> Non
             parlamentar = Parlamentar(
                 id=parlamentar_id,
                 casa="Câmara",
-                nome_eleitoral=ultimo_status.get("nomeEleitoral") or autor.get("nome"),
+                nome_eleitoral=ultimo_status.get(
+                    "nomeEleitoral") or autor.get("nome"),
                 sigla_partido=ultimo_status.get("siglaPartido", ""),
                 sigla_uf=ultimo_status.get("siglaUf", ""),
-                sexo=limpar_sexo(detalhes.get("sexo")),                          # Correção aplicada
+                # Correção aplicada
+                sexo=limpar_sexo(detalhes.get("sexo")),
                 url_foto=ultimo_status.get("urlFoto", ""),
                 status_mandato=ultimo_status.get("situacao", "Desconhecido")
             )
@@ -109,156 +125,190 @@ def upsert_autores_camara(session: Session, id_pl: int, autores_raw: Any) -> Non
                 tipo_autoria=autor.get("tipo")
             )
             session.merge(autoria)
-            
+
     except Exception as exc:
-        logger.error("Erro no upsert_autores_camara para o PL %d: %s", id_pl, exc)
+        logger.error(
+            "Erro no upsert_autores_camara para o PL %d: %s", id_pl, exc)
+
 
 def upsert_tramitacoes_camara(session: Session, id_pl: int, tramitacoes_raw: Any) -> None:
     try:
         tramitacoes_limpas = higienizar_para_jsonb(tramitacoes_raw)
         lista_tramitacoes = extrair_lista_camara(tramitacoes_limpas)
-        
-        for tramitacao in lista_tramitacoes:
-             if not isinstance(tramitacao, dict): continue
-                 
-             seq = tramitacao.get("sequencia")
-             data_t = tramitacao.get("dataHora")
-             
-             # Busca se já existe uma tramitação igual
-             query = session.query(TramitacaoCamara).filter(TramitacaoCamara.id_pl == id_pl)
-             if seq is not None:
-                 query = query.filter(TramitacaoCamara.sequencia == seq)
-             elif data_t is not None:
-                 query = query.filter(TramitacaoCamara.data_tramitacao == data_t)
-                 
-             existente = query.first()
 
-             if existente:
-                 # Atualiza
-                 existente.situacao = tramitacao.get("descricaoSituacao")
-                 existente.descricao = tramitacao.get("descricaoTramitacao")
-                 existente.local = tramitacao.get("siglaOrgao")
-                 existente.dados_raw = tramitacao
-             else:
-                 # Insere nova
-                 nova_tramitacao = TramitacaoCamara(
-                     id_pl=id_pl,
-                     data_tramitacao=data_t,
-                     situacao=tramitacao.get("descricaoSituacao"),
-                     descricao=tramitacao.get("descricaoTramitacao"),
-                     local=tramitacao.get("siglaOrgao"),
-                     sequencia=seq,
-                     dados_raw=tramitacao
-                  )
-                 session.add(nova_tramitacao)
-            
+        for tramitacao in lista_tramitacoes:
+            if not isinstance(tramitacao, dict):
+                continue
+
+            seq = tramitacao.get("sequencia")
+            data_t = tramitacao.get("dataHora")
+
+            # Busca se já existe uma tramitação igual
+            query = session.query(TramitacaoCamara).filter(
+                TramitacaoCamara.id_pl == id_pl)
+            if seq is not None:
+                query = query.filter(TramitacaoCamara.sequencia == seq)
+            elif data_t is not None:
+                query = query.filter(
+                    TramitacaoCamara.data_tramitacao == data_t)
+
+            existente = query.first()
+
+            if existente:
+                # Atualiza
+                existente.situacao = tramitacao.get("descricaoSituacao")
+                existente.descricao = tramitacao.get("descricaoTramitacao")
+                existente.local = tramitacao.get("siglaOrgao")
+                existente.dados_raw = tramitacao
+            else:
+                # Insere nova
+                nova_tramitacao = TramitacaoCamara(
+                    id_pl=id_pl,
+                    data_tramitacao=data_t,
+                    situacao=tramitacao.get("descricaoSituacao"),
+                    descricao=tramitacao.get("descricaoTramitacao"),
+                    local=tramitacao.get("siglaOrgao"),
+                    sequencia=seq,
+                    dados_raw=tramitacao
+                )
+                session.add(nova_tramitacao)
+
     except Exception as exc:
-        logger.error("Erro no upsert_tramitacoes_camara para o PL %d: %s", id_pl, exc)
+        logger.error(
+            "Erro no upsert_tramitacoes_camara para o PL %d: %s", id_pl, exc)
 
 # ---------------------------------------------------------------------------
 # UPSERTS DO SENADO FEDERAL
 # ---------------------------------------------------------------------------
 
+
 def navegar_seguro(payload: Any, caminho: List[str]) -> Any:
     atual = payload
     for chave in caminho:
-        if isinstance(atual, list): atual = atual[0] if atual else {}
-        if isinstance(atual, dict): atual = atual.get(chave, {})
-        else: return {}
+        if isinstance(atual, list):
+            atual = atual[0] if atual else {}
+        if isinstance(atual, dict):
+            atual = atual.get(chave, {})
+        else:
+            return {}
     return atual
 
+
 def garantir_lista(payload: Any) -> List[Any]:
-    if not payload or payload == {}: return []
-    if isinstance(payload, list): return payload
+    if not payload or payload == {}:
+        return []
+    if isinstance(payload, list):
+        return payload
     return [payload]
+
 
 def upsert_pl_senado(session: Session, item_raw: Any, dados_originais: Any) -> Optional[int]:
     try:
         raw_limpo = higienizar_para_jsonb(dados_originais)
-        
-        if isinstance(item_raw, list): item_raw = item_raw[0] if item_raw else {}
-        if not isinstance(item_raw, dict): return None
-            
+
+        if isinstance(item_raw, list):
+            item_raw = item_raw[0] if item_raw else {}
+        if not isinstance(item_raw, dict):
+            return None
+
         id_materia = item_raw.get("id")
-        if not id_materia: return None
-            
+        if not id_materia:
+            return None
+
         conteudo = item_raw.get("conteudo", {})
         documento = item_raw.get("documento", {})
         deliberacao = item_raw.get("deliberacao", {})
-        
+
         nova_pl = PlSenado(
-                id=int(id_materia),
-                codigo_materia=int(item_raw.get("codigoMateria", 0)),
-                identificacao=item_raw.get("identificacao", ""),
-                data_apresentacao=documento.get("dataApresentacao") or item_raw.get("dataApresentacao"),
-                data_deliberacao=deliberacao.get("data") or item_raw.get("dataDeliberacao"), 
-                ementa=conteudo.get("ementa") or item_raw.get("ementa", ""),
-                objetivo=conteudo.get("tipo") or item_raw.get("objetivo"),
-                tipo_documento=documento.get("tipo") or item_raw.get("tipoDocumento"),
-                tramitando=True if item_raw.get("tramitando") == "Sim" else False,
-                sigla_tipo_deliberacao=deliberacao.get("siglaTipo") or item_raw.get("siglaTipoDeliberacao"), 
-                dados_raw=raw_limpo
-         )
+            id=int(id_materia),
+            codigo_materia=int(item_raw.get("codigoMateria", 0)),
+            identificacao=item_raw.get("identificacao", ""),
+            data_apresentacao=documento.get(
+                "dataApresentacao") or item_raw.get("dataApresentacao"),
+            data_deliberacao=deliberacao.get(
+                "data") or item_raw.get("dataDeliberacao"),
+            ementa=conteudo.get("ementa") or item_raw.get("ementa", ""),
+            objetivo=conteudo.get("tipo") or item_raw.get("objetivo"),
+            tipo_documento=documento.get(
+                "tipo") or item_raw.get("tipoDocumento"),
+            tramitando=True if item_raw.get("tramitando") == "Sim" else False,
+            sigla_tipo_deliberacao=deliberacao.get(
+                "siglaTipo") or item_raw.get("siglaTipoDeliberacao"),
+            dados_raw=raw_limpo
+        )
         session.merge(nova_pl)
         return int(id_materia)
     except Exception as exc:
         logger.error("Erro no upsert_pl_senado: %s", exc)
         return None
 
+
 def upsert_autores_senado(session: Session, id_pl: int, detalhe_raw: Any) -> None:
     try:
         raw_limpo = higienizar_para_jsonb(detalhe_raw)
-        
+
         nodo_autores = (
             raw_limpo.get("autoriaIniciativa") or
             raw_limpo.get("documento", {}).get("autoria") or
-            raw_limpo.get("autores") or 
-            raw_limpo.get("autorias") or 
+            raw_limpo.get("autores") or
+            raw_limpo.get("autorias") or
             navegar_seguro(raw_limpo, ["Processo", "Autoria", "Autor"]) or
             navegar_seguro(raw_limpo, ["Materia", "Autoria", "Autor"])
         )
-        
+
         lista_autores = garantir_lista(nodo_autores)
-        
+
         if not lista_autores and isinstance(raw_limpo.get("autoria"), str):
             nome_autor = raw_limpo.get("autoria")
             parlamentar_id = f"sen_str_{id_pl}"
-            
+
             parlamentar = Parlamentar(
                 id=parlamentar_id, casa="Senado", nome_eleitoral=nome_autor,
                 sigla_partido="", sexo="M"
             )
             session.merge(parlamentar)
-            autoria = AutoriaSenado(id_pl=id_pl, id_parlamentar=parlamentar_id, tipo_autoria="Autor Principal")
+            autoria = AutoriaSenado(
+                id_pl=id_pl, id_parlamentar=parlamentar_id, tipo_autoria="Autor Principal")
             session.merge(autoria)
             return
 
         for autor_raw in lista_autores:
-            if not isinstance(autor_raw, dict): continue
+            if not isinstance(autor_raw, dict):
+                continue
 
-            parl_info = autor_raw.get("IdentificacaoParlamentar") or autor_raw.get("parlamentar") or autor_raw
-            if isinstance(parl_info, list): parl_info = parl_info[0] if parl_info else {}
-            
-            parl_id_api = parl_info.get("codigoParlamentar") or parl_info.get("CodigoParlamentar") or parl_info.get("codigo") or parl_info.get("id")
-            if not parl_id_api: continue
+            parl_info = autor_raw.get("IdentificacaoParlamentar") or autor_raw.get(
+                "parlamentar") or autor_raw
+            if isinstance(parl_info, list):
+                parl_info = parl_info[0] if parl_info else {}
+
+            parl_id_api = parl_info.get("codigoParlamentar") or parl_info.get(
+                "CodigoParlamentar") or parl_info.get("codigo") or parl_info.get("id")
+            if not parl_id_api:
+                continue
 
             parlamentar_id = f"sen_{parl_id_api}"
-            
+
             detalhes_extra = autor_raw.get("detalhes_senador", {})
-            parl_detalhe = navegar_seguro(detalhes_extra, ["DetalheParlamentar", "Parlamentar", "IdentificacaoParlamentar"])
+            parl_detalhe = navegar_seguro(
+                detalhes_extra, ["DetalheParlamentar", "Parlamentar", "IdentificacaoParlamentar"])
 
             # Captura o sexo bruto de onde ele estiver e passa pelo filtro
-            raw_sexo = parl_detalhe.get("SexoParlamentar") or parl_info.get("sexo")
+            raw_sexo = parl_detalhe.get(
+                "SexoParlamentar") or parl_info.get("sexo")
 
             parlamentar = Parlamentar(
                 id=parlamentar_id,
                 casa="Senado",
-                nome_eleitoral=parl_detalhe.get("NomeParlamentar") or parl_info.get("autor") or parl_info.get("nome") or "Desconhecido",
-                sigla_partido=parl_detalhe.get("SiglaPartidoParlamentar") or parl_info.get("siglaPartido") or "",
+                nome_eleitoral=parl_detalhe.get("NomeParlamentar") or parl_info.get(
+                    "autor") or parl_info.get("nome") or "Desconhecido",
+                sigla_partido=parl_detalhe.get(
+                    "SiglaPartidoParlamentar") or parl_info.get("siglaPartido") or "",
                 sigla_uf=parl_detalhe.get("uf") or parl_info.get("uf") or "",
-                sexo=limpar_sexo(raw_sexo),                                      # Correção aplicada
+                # Correção aplicada
+                sexo=limpar_sexo(raw_sexo),
                 url_foto=parl_detalhe.get("UrlFotoParlamentar") or "",
-                status_mandato=parl_detalhe.get("DescricaoParticipacao") or "Exercício"
+                status_mandato=parl_detalhe.get(
+                    "DescricaoParticipacao") or "Exercício"
             )
 
             session.merge(parlamentar)
@@ -266,78 +316,89 @@ def upsert_autores_senado(session: Session, id_pl: int, detalhe_raw: Any) -> Non
             autoria = AutoriaSenado(
                 id_pl=id_pl,
                 id_parlamentar=parlamentar_id,
-                tipo_autoria=autor_raw.get("descricaoTipo") or autor_raw.get("DescricaoTipoAutoria") or autor_raw.get("tipo") or "Autor"
+                tipo_autoria=autor_raw.get("descricaoTipo") or autor_raw.get(
+                    "DescricaoTipoAutoria") or autor_raw.get("tipo") or "Autor"
             )
             session.merge(autoria)
-        
+
     except Exception as exc:
-        logger.error("Erro no upsert_autores_senado para o PL %d: %s", id_pl, exc)
+        logger.error(
+            "Erro no upsert_autores_senado para o PL %d: %s", id_pl, exc)
+
 
 def upsert_tramitacoes_senado(session: Session, id_pl: int, movimentacoes_raw: Any) -> None:
     try:
         raw_limpo = higienizar_para_jsonb(movimentacoes_raw)
-        
+
         autuacoes = raw_limpo.get("autuacoes", [])
         informes_legislativos = []
         if isinstance(autuacoes, list) and len(autuacoes) > 0:
             for autuacao in autuacoes:
                 if isinstance(autuacao, dict):
-                    informes_legislativos.extend(autuacao.get("informesLegislativos", []))
+                    informes_legislativos.extend(
+                        autuacao.get("informesLegislativos", []))
 
         nodo_tramitacoes = (
             informes_legislativos or
-            raw_limpo.get("movimentacoes") or 
-            raw_limpo.get("andamentos") or 
-            raw_limpo.get("tramitacoes") or 
+            raw_limpo.get("movimentacoes") or
+            raw_limpo.get("andamentos") or
+            raw_limpo.get("tramitacoes") or
             navegar_seguro(raw_limpo, ["Processo", "Movimentacoes", "Movimentacao"]) or
-            navegar_seguro(raw_limpo, ["Materia", "Movimentacoes", "Movimentacao"])
+            navegar_seguro(
+                raw_limpo, ["Materia", "Movimentacoes", "Movimentacao"])
         )
-        
+
         lista_tramitacoes = garantir_lista(nodo_tramitacoes)
-    
+
         for idx, tramitacao in enumerate(lista_tramitacoes):
-            if not isinstance(tramitacao, dict): continue
-            
+            if not isinstance(tramitacao, dict):
+                continue
+
             ente_admin = tramitacao.get("enteAdministrativo", {})
-            local_nome = ente_admin.get("nome") or ente_admin.get("sigla") or tramitacao.get("DescricaoLocal") or tramitacao.get("local") or tramitacao.get("orgao")
-            
-            seq = tramitacao.get("id") or tramitacao.get("SequenciaMovimentacao") or tramitacao.get("sequencia") or (idx + 1)
-            data_t = tramitacao.get("data") or tramitacao.get("DataMovimentacao") or tramitacao.get("dataHora")
-            
+            local_nome = ente_admin.get("nome") or ente_admin.get("sigla") or tramitacao.get(
+                "DescricaoLocal") or tramitacao.get("local") or tramitacao.get("orgao")
+
+            seq = tramitacao.get("id") or tramitacao.get(
+                "SequenciaMovimentacao") or tramitacao.get("sequencia") or (idx + 1)
+            data_t = tramitacao.get("data") or tramitacao.get(
+                "DataMovimentacao") or tramitacao.get("dataHora")
+
             # Busca se já existe uma tramitação igual
-            query = session.query(TramitacaoSenado).filter(TramitacaoSenado.id_pl == id_pl)
+            query = session.query(TramitacaoSenado).filter(
+                TramitacaoSenado.id_pl == id_pl)
             if seq is not None:
-                 query = query.filter(TramitacaoSenado.sequencia == seq)
+                query = query.filter(TramitacaoSenado.sequencia == seq)
             elif data_t is not None:
-                 query = query.filter(TramitacaoSenado.data_tramitacao == data_t)
-                 
+                query = query.filter(
+                    TramitacaoSenado.data_tramitacao == data_t)
+
             existente = query.first()
 
             if existente:
-                existente.situacao = tramitacao.get("siglaSituacaoIniciada") or tramitacao.get("DescricaoMovimentacao") or tramitacao.get("situacao") or "Informação"
-                existente.descricao = tramitacao.get("descricao") or tramitacao.get("DescricaoMovimentacao") or tramitacao.get("texto")
+                existente.situacao = tramitacao.get("siglaSituacaoIniciada") or tramitacao.get(
+                    "DescricaoMovimentacao") or tramitacao.get("situacao") or "Informação"
+                existente.descricao = tramitacao.get("descricao") or tramitacao.get(
+                    "DescricaoMovimentacao") or tramitacao.get("texto")
                 existente.local = local_nome
                 existente.dados_raw = tramitacao
             else:
                 nova_tramitacao = TramitacaoSenado(
                     id_pl=id_pl,
                     data_tramitacao=data_t,
-                    situacao=tramitacao.get("siglaSituacaoIniciada") or tramitacao.get("DescricaoMovimentacao") or tramitacao.get("situacao") or "Informação",
-                    descricao=tramitacao.get("descricao") or tramitacao.get("DescricaoMovimentacao") or tramitacao.get("texto"),
+                    situacao=tramitacao.get("siglaSituacaoIniciada") or tramitacao.get(
+                        "DescricaoMovimentacao") or tramitacao.get("situacao") or "Informação",
+                    descricao=tramitacao.get("descricao") or tramitacao.get(
+                        "DescricaoMovimentacao") or tramitacao.get("texto"),
                     local=local_nome,
                     sequencia=seq,
                     dados_raw=tramitacao
                 )
                 session.add(nova_tramitacao)
-            
+
     except Exception as exc:
-        logger.error("Erro no upsert_tramitacoes_senado para o PL %d: %s", id_pl, exc)
+        logger.error(
+            "Erro no upsert_tramitacoes_senado para o PL %d: %s", id_pl, exc)
 
-
-
-
-
-from typing import Optional
 
 def normalizar_status_camara(descricao_situacao: Optional[str]) -> str:
     """
@@ -350,6 +411,7 @@ def normalizar_status_camara(descricao_situacao: Optional[str]) -> str:
     if descricao_situacao == "Arquivada":
         return "arquivado"
     return "em_tramitacao"
+
 
 def normalizar_status_senado(situacao_atual: Optional[str], tramitando: Optional[bool] = None) -> str:
     """

--- a/backend/popular_banco.py
+++ b/backend/popular_banco.py
@@ -2,18 +2,18 @@ import logging
 import argparse
 import json
 import time
-import os
 from datetime import datetime, timezone
 from dotenv import load_dotenv
 
 # Carrega variáveis do .env (como DATABASE_URL e OPENAI_API_KEY)
 load_dotenv()
 
-from app.database import SessionLocal
-from app.services.collector import coletar_camara, coletar_senado
+from app.database import SessionLocal  # noqa: E402
+from app.services.collector import coletar_camara, coletar_senado  # noqa: E402
 
 # Configura o log para você ver o progresso no terminal
 logging.basicConfig(level=logging.INFO)
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Script de Ingestão de PLs")
@@ -25,19 +25,20 @@ def parse_args():
     )
     return parser.parse_args()
 
+
 def executar_carga(mode: str, report_path: str = "ingestion-report.json"):
     print(f"Iniciando a carga de dados... Modo: {mode}")
-    
+
     start_time = time.time()
     started_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-    
+
     db = SessionLocal()
-    
+
     total_camara = 0
     total_senado = 0
     errors = []
     status = "success"
-    
+
     try:
         if mode == "full":
             ano = 2000
@@ -45,12 +46,12 @@ def executar_carga(mode: str, report_path: str = "ingestion-report.json"):
             print(f"Câmara finalizada! {total_camara} registros.")
             total_senado = coletar_senado(db, ano_inicial=ano)
             print(f"Senado finalizado! {total_senado} registros.")
-        else: # incremental
+        else:  # incremental
             total_camara = coletar_camara(db, numdias=2)
             print(f"Câmara finalizada! {total_camara} registros.")
             total_senado = coletar_senado(db, numdias=2)
             print(f"Senado finalizado! {total_senado} registros.")
-            
+
         print("Carga concluída com sucesso!")
     except Exception as e:
         status = "failure"
@@ -58,10 +59,10 @@ def executar_carga(mode: str, report_path: str = "ingestion-report.json"):
         print(f"Ocorreu um erro durante a carga: {e}")
     finally:
         db.close()
-        
+
     finished_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     duration_seconds = int(time.time() - start_time)
-    
+
     report = {
         "mode": mode,
         "started_at": started_at,
@@ -73,15 +74,17 @@ def executar_carga(mode: str, report_path: str = "ingestion-report.json"):
         "errors": errors,
         "status": status
     }
-    
+
     with open(report_path, "w") as f:
         json.dump(report, f, indent=2)
-        
+
     print(f"Relatório gerado em {report_path}")
+
 
 def carga_inicial():
     args = parse_args()
     executar_carga(args.mode)
+
 
 if __name__ == "__main__":
     carga_inicial()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,5 @@ requests>=2.31.0
 google-genai>=0.2.0
 pytest>=8.0.0
 python-dotenv>=1.0.0
+cachetools
+ruff>=0.4.0

--- a/backend/tests/test_collector.py
+++ b/backend/tests/test_collector.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch, MagicMock
 from app.services.collector import coletar_camara, coletar_senado
 from app.services import camara_client, senado_client

--- a/backend/tests/test_graficos_resumo.py
+++ b/backend/tests/test_graficos_resumo.py
@@ -2,11 +2,11 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 import pytest
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 from app.main import app
 from app.database import get_db, Base
-from app.models import PlCamara, PlSenado, Parlamentar, AutoriaCamara, TramitacaoCamara
+from app.models import PlCamara, Parlamentar, AutoriaCamara, TramitacaoCamara
 
 # Setup test DB
 SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"

--- a/backend/tests/test_merge_reports.py
+++ b/backend/tests/test_merge_reports.py
@@ -1,5 +1,4 @@
 import json
-import os
 from scripts.merge_reports import merge_reports
 
 def test_merge_reports_creates_history_if_not_exists(tmp_path):

--- a/backend/tests/test_nlp_service.py
+++ b/backend/tests/test_nlp_service.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 from unittest.mock import patch, MagicMock
 from app.services.nlp_service import get_dynamic_keywords
 

--- a/backend/tests/test_popular_banco.py
+++ b/backend/tests/test_popular_banco.py
@@ -1,7 +1,5 @@
 import sys
-import argparse
 import json
-import os
 from popular_banco import parse_args, executar_carga
 
 def test_parse_args_default_incremental(mocker):


### PR DESCRIPTION
## O que foi feito
Configuração do Ruff como linter do backend e correção de todos os erros encontrados.

## Mudanças
- Adicionado `ruff>=0.4.0` ao `requirements.txt`
- `app/models.py` — corrigido import fora do topo do arquivo (E402)
- `app/services/camara_client.py` — corrigido import fora do topo do arquivo (E402)
- `app/services/graficos.py` — corrigido statement múltiplo na mesma linha (E701)
- `app/services/normalizer.py` — corrigidos 22 statements múltiplos na mesma linha (E701) e removido import duplicado
- `popular_banco.py` — adicionado `# noqa: E402` nos imports que dependem do `load_dotenv()` rodar antes (ordem intencional)
- Diversos imports não utilizados removidos automaticamente via `ruff check --fix`

## Como testar
1. `docker-compose up --build`
2. `docker-compose exec backend sh`
3. `ruff check .`
4. Resultado esperado: `All checks passed!`

## Observações
Nenhuma lógica de negócio foi alterada — apenas formatação e organização de imports.

Closes #110 