### PR TITLE
ci: adiciona GitHub Actions para rodar linter automaticamente

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,52 @@
+name: Lint
+
+on:
+  push:
+    branches: [main, Dev]
+  pull_request:
+    branches: [main, Dev]
+
+jobs:
+  lint-backend:
+    name: Lint Backend (Ruff)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout código
+        uses: actions/checkout@v4
+
+      - name: Configurar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Instalar dependências do backend
+        working-directory: ./backend
+        run: pip install -r requirements.txt
+
+      - name: Rodar Ruff
+        working-directory: ./backend
+        run: ruff check .
+
+  lint-frontend:
+    name: Lint Frontend (ESLint)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout código
+        uses: actions/checkout@v4
+
+      - name: Configurar Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ./frontend/package-lock.json
+
+      - name: Instalar dependências do frontend
+        working-directory: ./frontend
+        run: npm ci
+
+      - name: Rodar ESLint
+        working-directory: ./frontend
+        run: npm run lint

--- a/frontend/src/components/Graficos/CardTempoTramitacao.jsx
+++ b/frontend/src/components/Graficos/CardTempoTramitacao.jsx
@@ -1,11 +1,4 @@
-const BADGE_CONFIG = {
-  aumento: { icone: '↗', bg: 'bg-pink-50', texto: 'text-red-700', sinal: '+' },
-  reducao: { icone: '↘', bg: 'bg-green-50', texto: 'text-green-700', sinal: '-' },
-};
-
 export default function CardTempoTramitacao({ dados }) {
-  const badge = BADGE_CONFIG[dados.tendencia] ?? BADGE_CONFIG.aumento;
-
   return (
     <div className="bg-white border border-gray-200 rounded-xl p-6 relative flex flex-col h-full">
       {/* Header alinhado à esquerda, igual aos outros cards */}


### PR DESCRIPTION
## O que foi feito
Configuração de um workflow do GitHub Actions para rodar o linter automaticamente em todo push e pull request para `main` e `Dev`.

## Mudanças
- Criado `.github/workflows/lint.yml` com 2 jobs paralelos:
  - **Lint Backend (Ruff)** — instala dependências do backend e roda `ruff check .`
  - **Lint Frontend (ESLint)** — instala dependências do frontend e roda `npm run lint`

## Como funciona
A partir desse PR, todo PR aberto para `main` ou `Dev` vai mostrar automaticamente dois checks:
- ✅/❌ Lint Backend (Ruff)
- ✅/❌ Lint Frontend (ESLint)

Se algum erro for encontrado, o check falha e mostra o log completo direto no PR, sem precisar rodar nada localmente para descobrir.

## Como testar
Após o merge, abrir qualquer PR novo e verificar se os 2 checks aparecem na parte inferior, executando automaticamente.

Closes #111